### PR TITLE
Update example-movies.md

### DIFF
--- a/source/example-movies.md
+++ b/source/example-movies.md
@@ -654,7 +654,7 @@ const mutations = {
     
     mutation(root, {document}, context) {
       
-      Utils.performCheck(this, context.currentUser, document);
+      Utils.performCheck(this.check, context.currentUser, document);
 
       return newMutation({
         collection: context.Movies,


### PR DESCRIPTION
At the mutation part, it was Utils.performCheck(this, context.currentUser, document);

It was not working .. so I saw at the example in the repo that now it is using 

At the mutation part, it was Utils.performCheck(this.check, context.currentUser, document);


It was accusing error when I was trying to create a new movie 