### PR TITLE
Corrected the collection name

### DIFF
--- a/source/example-movies.md
+++ b/source/example-movies.md
@@ -294,7 +294,7 @@ import resolvers from './resolvers.js';
 
 const Movies = createCollection({
 
-  collectionName: 'movies',
+  collectionName: 'Movies',
 
   typeName: 'Movie',
 


### PR DESCRIPTION
Using `collectionName: 'movies'` throws error on console: 
``` 
(STDERR) TypeError: Cannot read property 'find' of undefined
(STDERR)     at Object.resolvers.list.resolver (packages/my-package/lib/modules/movies/resolvers.js:8:14)
...
```

Changing it to `collectionName: 'Movies'` fixes the issue.