### PR TITLE
Add troubleshooting tip when `npm start` fails

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -23,6 +23,13 @@ npm install
 npm start
 ```
 
+**Troubleshooting Tip**: If your app fails to start, try 
+
+```sh
+meteor reset
+npm start
+```
+
 And open `http://localhost:3000/` in your browser.
 
 Note that you can also start the app with:


### PR DESCRIPTION
https://vulcanjs.slack.com/archives/C4K37H9PV/p1500747939797186

While getting started, I ran into this error after `npm start`

```sh
/Users/ChrisGeirman/.meteor/packages/fourseven_scss/.4.5.0.sccu8++os+web.browser+web.cordova/plugin.compileScssBatch.os/npm/node_modul
es/meteor/promise/node_modules/meteor-promise/promise_server.js:165
      throw error;
      ^
```

and running `meteor reset` worked for me.