### PR TITLE
changing typeName to type, for field resolvers

### DIFF
--- a/source/example-movies.md
+++ b/source/example-movies.md
@@ -514,7 +514,7 @@ userId: {
   viewableBy: ['guests'],
   resolveAs: {
     fieldName: 'user',
-    typeName: 'User',
+    type: 'User',
     resolver: (movie, args, context) => {
       return context.Users.findOne({ _id: movie.userId }, { fields: context.Users.getViewableFields(context.currentUser, context.Users) });
     },
@@ -826,7 +826,7 @@ const schema = {
     viewableBy: ['guests'],
     resolveAs: {
       fieldName: 'user',
-      typeName: 'User',
+      type: 'User',
       resolver: (movie, args, context) => {
         return context.Users.findOne({ _id: movie.userId }, { fields: context.Users.getViewableFields(context.currentUser, context.Users) });
       }


### PR DESCRIPTION
i dont know why. it just didnt run otherwise, and this was the only fix I found by checking `example-simple`