### PR TITLE
Forms custom syntax fixes

### DIFF
--- a/source/forms-custom.md
+++ b/source/forms-custom.md
@@ -19,7 +19,7 @@ For example, a useful pattern might be including a hidden Formsy `<Input/>`, and
 ```js
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Input } from 'formsy-react-component';
+import { Input } from 'formsy-react-components';
 
 class MyCustomFormComponent extends PureComponent {
   
@@ -62,7 +62,7 @@ Another method to achieve the same thing is to call `this.context.updateCurrentV
 ```js
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Input } from 'formsy-react-component';
+import { Input } from 'formsy-react-components';
 
 class MyCustomFormComponent extends PureComponent {
   

--- a/source/forms-custom.md
+++ b/source/forms-custom.md
@@ -27,7 +27,7 @@ class MyCustomFormComponent extends PureComponent {
     super();
     this.toggleMessage = this.toggleMessage.bind(this);
     this.state = {
-      message = 'foo'
+      message: 'foo'
     };
   }
 
@@ -70,7 +70,7 @@ class MyCustomFormComponent extends PureComponent {
     super();
     this.toggleMessage = this.toggleMessage.bind(this);
     this.state = {
-      message = 'foo'
+      message: 'foo'
     };
   }
 


### PR DESCRIPTION
Just a couple fixes for syntax errors I spotted while working through the tutorials.