### PR TITLE
mailgun settings

### DIFF
--- a/source/settings.md
+++ b/source/settings.md
@@ -43,6 +43,12 @@ These settings are defined at the root of the settings object, (or optionally on
 | --- | --- | --- |
 | mailUrl | "smtp://username:password@smtp.mailgun.org:587/" | The SMTP URL used by your email provider |
 
+**MailGun** Note:
+For `username` use your **Default SMTP Login**  and for `password` use **Default Password**. 
+See screenshot below.
+
+![](https://i.imgur.com/pRwaQzX.png)
+
 #### OAuth Settings
 
 You can use the settings file to store your oAuth configurations:


### PR DESCRIPTION
MailGun Note: For username use your Default SMTP Login and for password use Default Password. See screenshot below.

@SachaG I wanted to updated docs for mailgun setup, so it doesnt bring confusion.

If you think that big image is to much, feel free to just link it.