### PR TITLE
Update field-resolvers.md

### DIFF
--- a/source/field-resolvers.md
+++ b/source/field-resolvers.md
@@ -37,6 +37,9 @@ We are doing five things here:
 
 Note that it is recommended that you pick a **different** name for the "real" database field (`userId`) and the field in your schema (`user`), especially if you set `addOriginalField` to `true`. This way, you will be able to unambiguously require either the `_id` or the full user object just by specifying which field you need. 
 
+Also, the resolved type is a GraphQL type, not a primitive type or a schema. Therefore, it must necessarilly be a string (`'User'` in the previous example). If you rather need an array of user, the resolved type will be `'[User]'`. For primitive types, you must provide the name as a string, instead of the constructor : `'Date'` for a `Date`, `'String'` for a `String` etc.
+
+
 ## Custom Types
 
 Creating a collection with `createCollection` will automatically create the associated GraphQL type, but in some case you might want to resolve a field to a GraphQL type that doesn't correspond to any existing collection. 


### PR DESCRIPTION
This issue is tricky. When you want to resolve a Date field for example, you'll be tempted to write 
```
type:Date,
resolveAs:{
type: Date, // wrong, should be 'Date' here, but the reflex is to set both types to the same value
resolver() {...}
```
The first type expects a Constructor, the second a GraphQL type name as a string, but one can easily forget the quotes. 
The error message is then hardly understandable. In this example the type name will become "function Date()" and create invalid gql schema, but the solution is not trivial. 
So that would be nice to add this on the doc (or improve the error message).