### PR TITLE
Complete plugins.md and add two-repo tips for mup in deployment.md. Closes issue #63

### DIFF
--- a/source/deployment.md
+++ b/source/deployment.md
@@ -73,6 +73,13 @@ Still in the same folder, to deploy your app with your settings file:
 mup deploy --settings settings.json
 ```
 
+If you are using the [two-repo install](http://docs.vulcanjs.org/#Two-Repo-Install-Optional) you must specify the path to your package directory:
+```
+METEOR_PACKAGE_DIRS="/Users/sacha/Vulcan/packages" mup deploy --settings settings.json
+```
+
+(Taking care to adapt the `/Users/sacha/Vulcan/packages` path to point to your Vulcan core repo's `/packages` directory)
+
 ### Troubleshooting
 
 - `meteor npm install --save bcrypt`.
@@ -126,7 +133,7 @@ now alias set https://xxxxxxxxx.now.sh https://mydomain.now.sh
 
 That's it! now visit `https://mydomain.now.sh`.
 
-For more info, for how to get a custom domain name run `now -h`. You may need a premium [now](http://zeit.co/now) account. 
+For more info, for how to get a custom domain name run `now -h`. You may need a premium [now](http://zeit.co/now) account.
 
 ## PM2
 

--- a/source/plugins.md
+++ b/source/plugins.md
@@ -2,4 +2,10 @@
 title: Plugins
 ---
 
-Coming soon…
+VulcanJS is open-sourced and community-based, so it features some plugins developped by the community:
+
+- [ErikDakoda/vulcan-material-ui](https://github.com/ErikDakoda/vulcan-material-ui) : Replacement for Vulcan components using Material-UI.
+- [voodooattack/file-scalar](https://github.com/voodooattack/file-scalar) : A `File` scalar for Vulcan.js to facilitate file uploads with GraphQL.
+- [VulcanJS/vulcan-places](https://github.com/VulcanJS/vulcan-places) : Google Maps Places integration for Vulcan.
+
+If you have written a package and would like to see it registered here, you can [edit this page](https://github.com/VulcanJS/vulcan-docs/blob/master/source/plugins.md) and submit a PR to the docs.


### PR DESCRIPTION
- As mentioned in #63 I added some packages to plugins.md
- deployment.md now explains how to use mup with a two-repo install