### PR TITLE
Fix last 404s due to data-loading page removal

### DIFF
--- a/source/example-instagram.md
+++ b/source/example-instagram.md
@@ -6,11 +6,10 @@ Here's a [video walkthrough](https://www.youtube.com/watch?v=qibyA_ReqEQ) of [th
 
 ### Note: Code Changes
 
-Unlike the video, the actual package now relies on [default resolvers](/data-loading.html#Default-Resolvers) and [default mutations](/mutations.html#Default-Mutations) to simplify the code, meaning the `resolvers.js` and `mutations.js` files were removed. 
+Unlike the video, the actual package now relies on [default resolvers](/resolvers.html#Default-Resolvers) and [default mutations](/mutations.html#Default-Mutations) to simplify the code, meaning the `resolvers.js` and `mutations.js` files were removed. 
 
-Also, resolvers for the `userId` and `commentsCount` fields are now specified directly in the schema instead of in the `resolvers.js` file. 
+Also, resolvers for the `userId` and `commentsCount` fields are now specified directly in the schema instead of in the `resolvers.js` file.
 
 ### Image Upload
 
 This example uses [the `vulcan:forms-upload` package](forms-upload.html), which  uploads images to [Cloudinary](http://cloudinary.com).
-

--- a/source/nutshell.md
+++ b/source/nutshell.md
@@ -2,7 +2,7 @@
 title: Vulcan in a Nutshell
 ---
 
-The best way to understand how Vulcan works is to consider its three main aspects: the role of the schema, how Vulcan reads data, and how Vulcan writes data. 
+The best way to understand how Vulcan works is to consider its three main aspects: the role of the schema, how Vulcan reads data, and how Vulcan writes data.
 
 ## Overview
 
@@ -22,20 +22,20 @@ The schema is what defines how a [Collection](/schemas.html) (a.k.a. a Model) be
 
 Reading data basically means getting data from your database all the way to the user's browser.
 
-Let's assume you have a `Movies.jsx` component ready to take a `results` prop and display its contents as a list of movies. 
+Let's assume you have a `Movies.jsx` component ready to take a `results` prop and display its contents as a list of movies.
 
-In order to pass that prop, you'll wrap your component with the [`withList` higher-order component](http://docs.vulcanjs.org/data-loading.html#withList). You just need to specify the appropriate [Collection](/schemas.html), and optionally also specify a [fragment](/fragments.html) to define which document fields to load. 
+In order to pass that prop, you'll wrap your component with the [`withList` higher-order component](/resolvers.html#withList). You just need to specify the appropriate [Collection](/schemas.html), and optionally also specify a [fragment](/fragments.html) to define which document fields to load.
 
-The `withList` HoC will then query your GraphQL endpoint's corresponding [`MoviesList` resolver](/data-loading.html#List-Resolver), which can be generated automatically using Vulcan's [default resolvers](/data-loading.html#Default-Resolvers).
+The `withList` HoC will then query your GraphQL endpoint's corresponding [`MoviesList` resolver](/resolvers.html#List-Resolver), which can be generated automatically using Vulcan's [default resolvers](/resolvers.html#Default-Resolvers).
 
-The `MoviesList` resolver will optionally check the query's `terms` argument and [feed it through a set of callbacks](/terms-parameters.html) in order to generate a valid MongoDB query, whose result it will return to `withList` and from there back to your `Movies` component. 
+The `MoviesList` resolver will optionally check the query's `terms` argument and [feed it through a set of callbacks](/terms-parameters.html) in order to generate a valid MongoDB query, whose result it will return to `withList` and from there back to your `Movies` component.
 
 ## Writing Data
 
-Now let's consider the opposite operation: writing data, such as editing a movie's description. 
+Now let's consider the opposite operation: writing data, such as editing a movie's description.
 
-First, you should know that the movie edit form can be [automatically generated from your schema](/forms.html), meaning you don't actually need to code it or worry about hooking it up to your GraphQL API. 
+First, you should know that the movie edit form can be [automatically generated from your schema](/forms.html), meaning you don't actually need to code it or worry about hooking it up to your GraphQL API.
 
 That form is wrapped with the [`withEdit` HoC](/mutations.html#Higher-Order-Components), which in turn will call the `EditMovies` mutation on the server (which again can be [automatically generated from default mutations](/mutations.html#Default-Mutations)).
 
-`EditMovies` will then call a [boilerplate mutator](/mutations.html#Boilerplate-Mutations) which will perform **validation** based on your schema, and finally modify the document inside your database. 
+`EditMovies` will then call a [boilerplate mutator](/mutations.html#Boilerplate-Mutations) which will perform **validation** based on your schema, and finally modify the document inside your database.

--- a/source/schema-properties.md
+++ b/source/schema-properties.md
@@ -30,7 +30,7 @@ If it's a function, it'll be called on the `user` performing the operation, and 
 
 #### `resolveAs`
 
-You can learn more about `resolveAs` in the [Field Resolvers](/data-loading.html#Field-Resolvers) section.
+You can learn more about `resolveAs` in the [Field Resolvers](/field-resolvers.html) section.
 
 ### `onInsert`, `onEdit`, `onRemove`
 


### PR DESCRIPTION
I found there was a few 404s left on the docs:
- http://docs.vulcanjs.org/nutshell.html#Reading-Data
- http://docs.vulcanjs.org/example-instagram.html
- http://docs.vulcanjs.org/schema-properties.html#Data-Layer-Properties

and fixed them by putting the right links instead.