### PR TITLE
Update core-components.md

### DIFF
--- a/source/core-components.md
+++ b/source/core-components.md
@@ -38,7 +38,7 @@ It accepts the following props:
 
 All props are optional, but you should pass at least either `component` or `label`. 
 
-Note that the element passed as `component` needs to accept an `onClick` handler. In some cases, it might be necessary to wrap it inside an extra `<div`:
+Note that the element passed as `component` needs to accept an `onClick` handler. In some cases, it might be necessary to wrap it inside an extra `<div>`:
 
 ```js
 <Components.ModalTrigger size={size} title="New Post" component={<div><MyButton/></div>}>


### PR DESCRIPTION
Small typo fix. Added angle bracket to close properly: `<div` ==> `<div>`