### PR TITLE
Update example-movies.md – Fix MoviesList Component Name.

### DIFF
--- a/source/example-movies.md
+++ b/source/example-movies.md
@@ -591,7 +591,7 @@ import { Components, registerComponent, withMulti, withCurrentUser, Loading } fr
 
 import Movies from '../../modules/movies/collection.js';
 
-const movies = ({results = [], currentUser, loading, loadMore, count, totalCount}) => 
+const MoviesList = ({results = [], currentUser, loading, loadMore, count, totalCount}) => 
   
   <div style={ { maxWidth: '500px', margin: '20px auto' } }>
 


### PR DESCRIPTION
At line 594, the component name is incorrect, which causes the list of movies not to load if one is copy and pasting from the docs when updating their app.