### PR TITLE
remove FastClick (no longer needed)

### DIFF
--- a/themes/meteor/layout/layout.ejs
+++ b/themes/meteor/layout/layout.ejs
@@ -34,9 +34,6 @@
     <%- body %>
     <script src="<%= config.root || '/' %>script/smooth-scroll.min.js"></script>
     <script src="<%= config.root || '/' %>script/main.js"></script>
-    <script type="text/javascript" src="//cdn.jsdelivr.net/fastclick/1.0.6/fastclick.min.js"></script>
-
-
     <script>
       <% if (config.redirects) { %>
         var REDIRECTS = <%- JSON.stringify(config.redirects, 0, 2) %>;


### PR DESCRIPTION
Mobile browsers no longer have a 300ms touch delay. 

REF: https://github.com/ftlabs/fastclick#fastclick