### PR TITLE
Add document-level permissions

### DIFF
--- a/source/example-movies.md
+++ b/source/example-movies.md
@@ -828,7 +828,6 @@ const Movies = createCollection({
   }
   //...
 })
-//...
 ```
 
 Note that in this specific case, creating an action and checking for it is a bit superfluous, as it boils down to checking if the user is logged in. But this is a good introduction to the permission patterns used in Vulcan, which you can learn more about in the [Groups & Permissions](/groups-permissions.html) section.

--- a/source/example-movies.md
+++ b/source/example-movies.md
@@ -918,12 +918,13 @@ import React, { PropTypes, Component } from 'react';
 import { Components, registerComponent, withCurrentUser, getFragment } from 'meteor/vulcan:core';
 
 import Movies from '../../modules/movies/collection.js';
+import Users from "meteor/vulcan:users";
 
 const MoviesNewForm = ({currentUser}) =>
 
   <div>
 
-    {Movies.canCreate({
+    {Users.canCreate({
       collection: Gyms,
       user: currentUser
     }) ?

--- a/source/example-movies.md
+++ b/source/example-movies.md
@@ -925,7 +925,7 @@ const MoviesNewForm = ({currentUser}) =>
   <div>
 
     {Users.canCreate({
-      collection: Gyms,
+      collection: Movies,
       user: currentUser
     }) ?
       <div style={ { marginBottom: '20px', paddingBottom: '20px', borderBottom: '1px solid #ccc' } }>

--- a/source/example-movies.md
+++ b/source/example-movies.md
@@ -819,6 +819,15 @@ import './fragments.js';
 import mutations from './mutations.js';
 import './permissions.js';
 
+const Movies = createCollection({
+  permissions: {
+    canCreate: ["members"],
+    canRead: ["guests"],
+    canUpdate: ["owners", "admins"],
+    canDelete: ["owners", "admins"]
+  }
+  //...
+})
 //...
 ```
 
@@ -827,6 +836,8 @@ Note that in this specific case, creating an action and checking for it is a bit
 One more thing! By default, all schema fields are locked down, so we need to specify which ones the user should be able to insert as part of a “new document” operation. 
 
 Once again, we do this through the schema. We'll add an `canCreate` property to any “insertable” field and set it to `[members]` to indicate that a field should be insertable by any member of the `members` group (in other words, regular logged-in users):
+
+We also add [document-level permissions](/groups-permissions.html#Document-level-Permissions) to give permissions on a document level and allow us to [add permissions](/groups-permissions.html#Checking-Permissions) on the client.
 
 ```js
 const schema = {
@@ -913,7 +924,10 @@ const MoviesNewForm = ({currentUser}) =>
 
   <div>
 
-    {Movies.options.mutations.create.check(currentUser) ?
+    {Movies.canCreate({
+      collection: Gyms,
+      user: currentUser
+    }) ?
       <div style={ { marginBottom: '20px', paddingBottom: '20px', borderBottom: '1px solid #ccc' } }>
         <h4>Insert New Document</h4>
         <Components.SmartForm 
@@ -938,7 +952,7 @@ import '../components/movies/MoviesNewForm.jsx';
 A few things to note: 
 
 - We'll pass the `MoviesItemFragment` fragment to the form so that it knows what data to return from the server once the mutation is complete. 
-- We only want to show the “New Movie” form when a user actually *can* submit a new movie, so we'll make use of the `create` mutation's `check` function to figure this out.
+- We only want to show the “New Movie” form when a user actually *can* submit a new movie, so we'll make use of the document level permissions we defined earlier to check if a user can create a movie using the `canCreate` helper on the collection.
 - We need to access the current user to perform this check, so we'll use the `withCurrentUser` higher-order component. 
 
 Let's add the form component to `movies.jsx`:


### PR DESCRIPTION
Whilst working through the movies example I was unable to proceed unless I added document level permissions. I read about the updates here: https://blog.vulcanjs.org/vulcan-js-1-14-filtering-new-apis-fc8efc0027dd

I'm not sure if anything else here should be removed apart from `check`, but it should be enough for a beginner to proceed past this point.

* Added document level permissions
* Removed check in favour of `Users.canCreate`