### PR TITLE
Add "S" hotkey to docs to focus the search input

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "version": "3.9.0"
   },
   "dependencies": {
-    "@github/hotkey": "^1.4.2",
     "global": "^4.3.2",
     "handlebars": "^4.1.2",
     "hexo": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "version": "3.9.0"
   },
   "dependencies": {
+    "@github/hotkey": "^1.4.2",
     "global": "^4.3.2",
     "handlebars": "^4.1.2",
     "hexo": "^3.8.0",

--- a/themes/meteor/layout/layout.ejs
+++ b/themes/meteor/layout/layout.ejs
@@ -34,6 +34,7 @@
   <body class="">
     <%- body %>
     <script src="<%= config.root || '/' %>script/smooth-scroll.min.js"></script>
+    <script src="<%= config.root || '/' %>script/hotkey.js"></script>
     <script src="<%= config.root || '/' %>script/main.js"></script>
     <script>
       <% if (config.redirects) { %>

--- a/themes/meteor/layout/page.ejs
+++ b/themes/meteor/layout/page.ejs
@@ -21,7 +21,7 @@
 
     <div class="nav-item wrapper-search">
       <div class="input-symbol small round">
-        <input type="text" placeholder="Search <%- config.subtitle %>" id="desktop-search-input" />
+        <input type="text" placeholder="Search <%- config.subtitle %>" id="desktop-search-input" data-hotkey="s" />
         <span class="icon-search"></span>
       </div>
       <div class="wrapper-desktop-search-results"></div>

--- a/themes/meteor/source/script/hotkey.js
+++ b/themes/meteor/source/script/hotkey.js
@@ -1,0 +1,178 @@
+// from npm package @github/hotkey | MIT
+
+
+(function (global, factory) {
+  typeof exports === "object" && typeof module !== "undefined"
+    ? (module.exports = factory())
+    : typeof define === "function" && define.amd
+    ? define(factory)
+    : ((global = global || self), (global.Hotkey = factory()));
+})(this, function () {
+  "use strict";
+
+  class Leaf {
+    constructor(trie) {
+      this.children = [];
+      this.parent = trie;
+    }
+    delete(value) {
+      const index = this.children.indexOf(value);
+      if (index === -1) return false;
+      this.children = this.children
+        .slice(0, index)
+        .concat(this.children.slice(index + 1));
+      if (this.children.length === 0) {
+        this.parent.delete(this);
+      }
+      return true;
+    }
+    add(value) {
+      this.children.push(value);
+      return this;
+    }
+  }
+  class RadixTrie {
+    constructor(trie) {
+      this.parent = null;
+      this.children = {};
+      this.parent = trie || null;
+    }
+    get(edge) {
+      return this.children[edge];
+    }
+    insert(edges) {
+      let currentNode = this;
+      for (let i = 0; i < edges.length; i += 1) {
+        const edge = edges[i];
+        let nextNode = currentNode.get(edge);
+        if (i === edges.length - 1) {
+          if (nextNode instanceof RadixTrie) {
+            currentNode.delete(nextNode);
+            nextNode = null;
+          }
+          if (!nextNode) {
+            nextNode = new Leaf(currentNode);
+            currentNode.children[edge] = nextNode;
+          }
+          return nextNode;
+        } else {
+          if (nextNode instanceof Leaf) nextNode = null;
+          if (!nextNode) {
+            nextNode = new RadixTrie(currentNode);
+            currentNode.children[edge] = nextNode;
+          }
+        }
+        currentNode = nextNode;
+      }
+      return currentNode;
+    }
+    delete(node) {
+      for (const edge in this.children) {
+        const currentNode = this.children[edge];
+        if (currentNode === node) {
+          const success = delete this.children[edge];
+          if (Object.keys(this.children).length === 0 && this.parent) {
+            this.parent.delete(this);
+          }
+          return success;
+        }
+      }
+      return false;
+    }
+  }
+
+  function isFormField(element) {
+    if (!(element instanceof HTMLElement)) {
+      return false;
+    }
+    const name = element.nodeName.toLowerCase();
+    const type = (element.getAttribute("type") || "").toLowerCase();
+    return (
+      name === "select" ||
+      name === "textarea" ||
+      (name === "input" &&
+        type !== "submit" &&
+        type !== "reset" &&
+        type !== "checkbox" &&
+        type !== "radio") ||
+      element.isContentEditable
+    );
+  }
+  function fireDeterminedAction(el) {
+    if (isFormField(el)) {
+      el.focus();
+    } else {
+      el.click();
+    }
+  }
+  function expandHotkeyToEdges(hotkey) {
+    return hotkey.split(",").map((edge) => edge.split(" "));
+  }
+
+  function hotkey(event) {
+    return `${
+      event.ctrlKey ? "Control+" : ""
+    }${event.altKey ? "Alt+" : ""}${event.metaKey ? "Meta+" : ""}${event.shiftKey && event.key.toUpperCase() !== event.key ? "Shift+" : ""}${event.key}`;
+  }
+
+  const hotkeyRadixTrie = new RadixTrie();
+  const elementsLeaves = new WeakMap();
+  let currentTriePosition = hotkeyRadixTrie;
+  let resetTriePositionTimer = null;
+  function resetTriePosition() {
+    resetTriePositionTimer = null;
+    currentTriePosition = hotkeyRadixTrie;
+  }
+  function keyDownHandler(event) {
+    if (event.defaultPrevented) return;
+    if (event.target instanceof Node && isFormField(event.target)) return;
+    if (resetTriePositionTimer != null) {
+      window.clearTimeout(resetTriePositionTimer);
+    }
+    resetTriePositionTimer = window.setTimeout(resetTriePosition, 1500);
+    const newTriePosition = currentTriePosition.get(hotkey(event));
+    if (!newTriePosition) {
+      resetTriePosition();
+      return;
+    }
+    currentTriePosition = newTriePosition;
+    if (newTriePosition instanceof Leaf) {
+      fireDeterminedAction(
+        newTriePosition.children[newTriePosition.children.length - 1]
+      );
+      event.preventDefault();
+      resetTriePosition();
+      return;
+    }
+  }
+  function install(element, hotkey) {
+    if (Object.keys(hotkeyRadixTrie.children).length === 0) {
+      document.addEventListener("keydown", keyDownHandler);
+    }
+    const hotkeys = expandHotkeyToEdges(
+      hotkey || element.getAttribute("data-hotkey") || ""
+    );
+    const leaves = hotkeys.map((h) => hotkeyRadixTrie.insert(h).add(element));
+    elementsLeaves.set(element, leaves);
+  }
+  function uninstall(element) {
+    const leaves = elementsLeaves.get(element);
+    if (leaves && leaves.length) {
+      for (const leaf of leaves) {
+        leaf && leaf.delete(element);
+      }
+    }
+    if (Object.keys(hotkeyRadixTrie.children).length === 0) {
+      document.removeEventListener("keydown", keyDownHandler);
+    }
+  }
+
+  const Hotkey = {
+    Leaf,
+    RadixTrie,
+    eventToHotkeyString: hotkey,
+    install,
+    uninstall,
+  };
+  return Hotkey;
+});

--- a/themes/meteor/source/script/main.js
+++ b/themes/meteor/source/script/main.js
@@ -45,7 +45,6 @@
 
   for (const el of document.querySelectorAll('[data-hotkey]')) {
     Hotkey.install(el)
-    console.log(el)
   }
 
   function createSubMenu (container, headers) {

--- a/themes/meteor/source/script/main.js
+++ b/themes/meteor/source/script/main.js
@@ -166,13 +166,6 @@
     })
   })
 
-  // fastclick to remove click delay in mobile browsers
-  if ('addEventListener' in document) {
-    document.addEventListener('DOMContentLoaded', function() {
-      FastClick.attach(document.body);
-    }, false);
-  }
-
   // search toggle
   var nav = document.querySelector('.nav');
   var mobileSearch = document.querySelector('#mobile-search-input');

--- a/themes/meteor/source/script/main.js
+++ b/themes/meteor/source/script/main.js
@@ -43,6 +43,11 @@
     })
   }
 
+  for (const el of document.querySelectorAll('[data-hotkey]')) {
+    Hotkey.install(el)
+    console.log(el)
+  }
+
   function createSubMenu (container, headers) {
     var subMenu = document.createElement('ul')
     subMenu.className = 'sub-menu'

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,6 +89,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@github/hotkey@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@github/hotkey/-/hotkey-1.4.2.tgz#35369f0f525712765f78d287ed615f7cd014721d"
+  integrity sha512-JBIHoy8XUoAfMCwsm2PY7z4BrrbpFJTzs1dPtQnMYCc78SA3Fko9daMvMULrpDn3vu+NkIxKfI93Pklwl8sy4g==
+
 JSONStream@^1.0.7:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,11 +89,6 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@github/hotkey@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@github/hotkey/-/hotkey-1.4.2.tgz#35369f0f525712765f78d287ed615f7cd014721d"
-  integrity sha512-JBIHoy8XUoAfMCwsm2PY7z4BrrbpFJTzs1dPtQnMYCc78SA3Fko9daMvMULrpDn3vu+NkIxKfI93Pklwl8sy4g==
-
 JSONStream@^1.0.7:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
This uses the npm package [github/hotkey](https://github.com/github/hotkey) . I had to copy & paste the code directly into a file because hexo has no js bundler, so you can't `import X from "package"` like you would with a proper build tool. The S hotkey is something that I always use on the [material-ui docs](https://material-ui.com/), and it's where I've had this idea.

I also found something that was no longer working on the main js script, it triggers an error on the current prod site. It's called [FastClick](https://github.com/ftlabs/fastclick), and it's apparently deprecated now (see note in their readme). I don't know if it has ever worked on the Vulcan doc, but I chose to remove it anyway.

I know this is a two-in-one PR, but the second thing came in at the end and is really not much. So I'm a little sorry about that, but not that much. If you don't like the hotkey part, I'll make a PR to remove the fastclick error.